### PR TITLE
Fix dependencies for Kodi 19 rc 1

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.kxmxpxtx.bandcamp" name="Bandcamp" version="0.0.4" provider-name="kxmxpxtx">
+<addon id="plugin.audio.kxmxpxtx.bandcamp" name="Bandcamp" version="0.0.4.1+matrix.1" provider-name="kxmxpxtx">
     <requires>
-        <import addon="xbmc.python" version="2.7.0"/>
-        <import addon="script.module.requests" version="2.9.1"/>
-        <import addon="script.module.future" version="0.17.1"/>
-        <import addon="script.common.plugin.cache" version="2.6.1"/>
+        <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="script.module.requests" version="2.22.0+matrix.1"/>
+        <import addon="script.module.future" version="0.18.2+matrix.1"/>
+        <import addon="script.common.plugin.cache" version="2.6.1.1"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>audio</provides>
@@ -14,8 +14,8 @@
         <license>MIT</license>
         <description lang="en_GB">Discover new artists and browse your collection</description>
         <platform>all</platform>
-        <news>v0.0.4 (2020-05-27)
-            - Fix click opening a band in the search
+        <news>v0.0.4.1+matrix.1 (2021-02-05)
+            - Fix dependencies for Kodi 19 rc 1
         </news>
         <assets>
             <icon>icon.png</icon>


### PR DESCRIPTION
Just minimal adaptions to allow the plugin to install (and run) under Kodi 19 rc 1 (Matrix)

Yatse interactions are working fine too, even from bandcamp android app.

Thanks for this nice plugin !