### PR TITLE
Added image quality setting and band fanart, updated settings format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,5 @@ download zip and add it to Kodi
 # todo
 * add caches collection and fan_id
 * add possibility to listen to all bands and albums in the collection
-* configure cover arts quality
 * add setting for discovery playlist size
 * add personal mix (e.g top punk-hardcore + new black metal)

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.kxmxpxtx.bandcamp" name="Bandcamp" version="0.0.4.1+matrix.1" provider-name="kxmxpxtx">
+<addon id="plugin.audio.kxmxpxtx.bandcamp" name="Bandcamp" version="0.4.2+matrix.1" provider-name="kxmxpxtx">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -14,8 +14,8 @@
         <license>MIT</license>
         <description lang="en_GB">Discover new artists and browse your collection</description>
         <platform>all</platform>
-        <news>v0.0.4.1+matrix.1 (2021-02-05)
-            - Fix dependencies for Kodi 19 rc 1
+        <news>v0.4.2+matrix.1 (2022-10-23)
+ - Added image quality settings and band fanart
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/default.py
+++ b/default.py
@@ -40,8 +40,8 @@ def build_band_list(bands, from_wishlist=False):
     xbmcplugin.endOfDirectory(addon_handle)
 
 
-def build_album_list(albums):
-    albums_list = list_items.get_album_items(albums)
+def build_album_list(albums, band):
+    albums_list = list_items.get_album_items(albums, band)
     xbmcplugin.addDirectoryItems(addon_handle, albums_list, len(albums_list))
     xbmcplugin.endOfDirectory(addon_handle)
 
@@ -117,15 +117,15 @@ def main():
         build_band_list(bandcamp.get_wishlist(bandcamp.get_fan_id()), from_wishlist=True)
     elif mode[0] == 'list_wishlist_albums':
         bands = bandcamp.get_wishlist(bandcamp.get_fan_id())
-        band = Band(band_id=args.get('band_id', None)[0])
-        build_album_list(bands[band])
+        band, albums = bandcamp.get_band(args.get('band_id', None)[0])
+        build_album_list(bands[band], band)
     elif mode[0] == 'list_search_albums':
         band, albums = bandcamp.get_band(args.get('band_id', None)[0])
-        build_album_list(albums)
+        build_album_list(albums, band)
     elif mode[0] == 'list_albums':
         bands = bandcamp.get_collection(bandcamp.get_fan_id())
-        band = Band(band_id=args.get('band_id', None)[0])
-        build_album_list(bands[band])
+        band, albums = bandcamp.get_band(args.get('band_id', None)[0])
+        build_album_list(bands[band], band)
     elif mode[0] == 'list_songs':
         album_id = args.get('album_id', None)[0]
         item_type = args.get('item_type', None)[0]

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -42,6 +42,38 @@ msgctxt "#30013"
 msgid "Recommended"
 msgstr ""
 
+msgctxt "#30014"
+msgid "General settings for the Bandcamp addon"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Add your username to view your collection and wishlist"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Choose what you will see in the Discover section"
+msgstr ""
+
+msgctxt "#30020"
+msgid "Image Quality"
+msgstr ""
+
+msgctxt "#30021"
+msgid "Set the desired quality level for album art and band images"
+msgstr ""
+
+msgctxt "#30022"
+msgid "High"
+msgstr ""
+
+msgctxt "#30023"
+msgid "Medium"
+msgstr ""
+
+msgctxt "#30024"
+msgid "Low"
+msgstr ""
+
 # GUI main menu
 msgctxt "#30101"
 msgid "Discover"

--- a/resources/lib/bandcamp_api/bandcamp.py
+++ b/resources/lib/bandcamp_api/bandcamp.py
@@ -16,9 +16,10 @@ from html.parser import HTMLParser
 
 
 class Band:
-    def __init__(self, band_id=None, band_name=""):
+    def __init__(self, band_id=None, band_name="", band_img=None):
         self.band_name = band_name
         self.band_id = str(band_id)
+        self.band_img = band_img
 
     def __eq__(self, other):
         if type(other) is type(self):
@@ -28,6 +29,10 @@ class Band:
 
     def __hash__(self):
         return hash(self.band_id)
+
+    def get_art_img(self, quality=20):
+        if self.band_img:
+            return "https://f4.bcbits.com/img/{band_img}_{quality}.jpg".format(band_img=self.band_img, quality=quality)
 
 
 class Album:
@@ -41,8 +46,9 @@ class Album:
         self.item_type = item_type
         self.genre = genre
 
-    def get_art_img(self, quality=9):
-        return "https://f4.bcbits.com/img/a0{art_id}_{quality}.jpg".format(art_id=self.art_id, quality=quality)
+    def get_art_img(self, quality=2):
+        if self.art_id:
+            return "https://f4.bcbits.com/img/a0{art_id}_{quality}.jpg".format(art_id=self.art_id, quality=quality)
 
 
 class Track:
@@ -95,7 +101,8 @@ class Bandcamp:
             album_genre = u'{genre} ({slice})'.format(genre=item['genre_text'], slice=slice)
             album = Album(album_id=item['id'], album_name=item['primary_text'], art_id=item['art_id'],
                           genre=album_genre, item_type=item['type'])
-            band = Band(band_id=item['band_id'], band_name=item['secondary_text'])
+            band = Band(band_id=item['band_id'], band_name=item['secondary_text'],
+                        band_img=item['bio_image']['image_id'])
             discover_list[band] = {album: [track]}
         return discover_list
 
@@ -156,7 +163,8 @@ class Bandcamp:
                     Track(track['title'], track['streaming_url']['mp3-128'], track['duration'],
                           number=track['track_num']))
         art_id = album_details['art_id']
-        band = Band(band_name=album_details['band']['name'], band_id=album_details['band']['band_id'])
+        band = Band(band_name=album_details['band']['name'], band_id=album_details['band']['band_id'],
+                    band_img=album_details['band']['image_id'])
         album = Album(album_id, album_details['title'], art_id)
         return band, album, track_list
 
@@ -199,7 +207,8 @@ class Bandcamp:
         body = '{{"band_id": "{band_id}"}}'.format(band_id=band_id)
         request = requests.post(url, data=body)
         band_details = json.loads(request.text)
-        band = Band(band_id=band_details['id'], band_name=band_details['name'])
+        band = Band(band_id=band_details['id'], band_name=band_details['name'],
+                    band_img=band_details['bio_image_id'])
         albums = []
         for album in band_details['discography']:
             albums.append(Album(album_id=album['item_id'], album_name=album['title'],
@@ -215,7 +224,8 @@ class Bandcamp:
         items = []
         for result in results:
             if result['type'] == "b":
-                item = Band(band_id=result['id'], band_name=result['name'])
+                item = Band(band_id=result['id'], band_name=result['name'],
+                            band_img=result['img'])
             else:
                 item = Album(album_id=result['id'], album_name=result['name'],
                              art_id=result['art_id'], item_type=result['type'])

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,11 +1,52 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-    <category label="30001">
-        <setting label="30002" type="text" id="username" default=""/>
-    </category>
-    <category label="30003">
-        <setting label="30011" type="bool" id="slice_top" default="true"/>
-        <setting label="30012" type="bool" id="slice_new" default="false"/>
-        <setting label="30013" type="bool" id="slice_rec" default="false"/>
-    </category>
+<?xml version="1.0" ?>
+<settings version="1">
+	<section id="plugin.audio.kxmxpxtx.bandcamp">
+		<category id="general" label="30001" help="30014">
+			<group id="1">
+				<setting id="username" type="string" label="30002" help="30015">
+					<level>0</level>
+					<default/>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="edit" format="string">
+						<heading>30002</heading>
+					</control>
+				</setting>
+				<setting id="image_quality" type="integer" label="30020" help="30021">
+					<level>0</level>
+					<default>1</default>
+					<constraints>
+						<options>
+							<option label="30022">0</option>
+							<option label="30023">1</option>
+							<option label="30024">2</option>
+						</options>
+					</constraints>
+					<control type="list" format="string">
+						<heading>30020</heading>
+					</control>
+				</setting>
+			</group>
+		</category>
+		<category id="discover" label="30003" help="30016">
+			<group id="1">
+				<setting id="slice_top" type="boolean" label="30011" help="30016">
+					<level>0</level>
+					<default>true</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="slice_new" type="boolean" label="30012" help="30016">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="slice_rec" type="boolean" label="30013" help="30016">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
+			</group>
+		</category>
+	</section>
 </settings>


### PR DESCRIPTION
Hi,

I have added some image quality settings, and band fanart in the background, to enhance the visual experience of browsing through Bandcamp albums.

Settings screen:
![screenshot](https://user-images.githubusercontent.com/45097569/197394190-cfad9242-4bab-4945-af62-aaa9fa2b9cf4.png)

Before:
![screen-1](https://user-images.githubusercontent.com/45097569/197394491-cdda9461-bf7f-4e30-9ea4-1728b28277b4.jpg)

After:
![screen-2](https://user-images.githubusercontent.com/45097569/197394495-c8c6ae0d-2c11-44b5-9ab8-292f37d70b44.jpg)

Let me know if there's anything I can improve about this PR. I have added a version number bump in preparation for a PR to `xbmc/repo-plugins`. I am happy to leave it out if there are other changes that should be included first.

Thank you for the plugin! Great for finding new music to listen to.